### PR TITLE
Unix Domain Socket support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 
+[features]
+default = ["unix-domain-sockets"]
+unix-domain-sockets = ["hyper/socket2"]
+
 [dependencies]
 axum = { version = "0.6.20", features = ["http2"] }
 ctrlc = "3.4.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Multiple Hyper servers are spawned on different endpoints to showcase the use of
 and ports while reusing the same server components. A Hyper service is used to switch the incoming traffic based on the
 `content-type` header and if `application/grpc` is detected, traffic is forwarded to the Tonic server; all other
 cases forward to Axum. This allows for transparent use of HTTP/1.1 and HTTP/2 (prior knowledge), as well
-as ALPN on the TLS-enabled ports.
+as ALPN on the TLS-enabled ports. On Unixoids, Unix Domain Sockets are supported as well. 
 
 This project uses:
 
@@ -70,8 +70,11 @@ grpcurl --insecure --use-reflection -d '{ "message": "World" }' 127.0.0.1:36850 
 
 ### Unix Domain Sockets
 
+For UDS to work with gRPC, the `:authority` header needs to be sent. In `grpcurl`, the `--authority=xyz` flag
+is used for that:
+
 ```shell
-curl -v --unix-socket /tmp/cohosting.sock http://localhost:36849/
+grpcurl --unix --plaintext --use-reflection --authority localhost -d '{ "message": "World" }' /tmp/cohosting.sock example.YourService/YourMethod
 ```
 
 ## Recommended reads

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ curl -v http://127.1.0.1:36849/
 curl --http2-prior-knowledge --insecure -vv http://127.0.0.1:36849/
 ```
 
+### Unix Domain Sockets
+
+```shell
+curl -v --unix-socket /tmp/cohosting.sock http://localhost:36849/
+```
+
 ### TLS with ALPN
 
 ```shell
@@ -60,6 +66,12 @@ Send a test request:
 ```shell
 grpcurl --plaintext --use-reflection -d '{ "message": "World" }' 127.0.0.1:36849 example.YourService/YourMethod
 grpcurl --insecure --use-reflection -d '{ "message": "World" }' 127.0.0.1:36850 example.YourService/YourMethod
+```
+
+### Unix Domain Sockets
+
+```shell
+curl -v --unix-socket /tmp/cohosting.sock http://localhost:36849/
 ```
 
 ## Recommended reads

--- a/src/hybrid.rs
+++ b/src/hybrid.rs
@@ -165,7 +165,7 @@ fn is_grpc_request<Body>(req: &Request<Body>) -> bool {
     }
 
     // The content-type header needs to start with `application/grpc`
-    const EXPECTED: &'static [u8] = b"application/grpc";
+    const EXPECTED: &[u8] = b"application/grpc";
     if let Some(content_type) = req
         .headers()
         .get(hyper::header::CONTENT_TYPE)

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -1,0 +1,48 @@
+use hyper::server::accept::Accept;
+use log::debug;
+use std::fs;
+use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::net::UnixListener;
+
+pub struct UnixDomainSocket {
+    inner: UnixListener,
+}
+
+impl UnixDomainSocket {
+    pub fn new(path: &Path) -> std::io::Result<Self> {
+        let listener = UnixListener::bind(path)?;
+        Ok(Self { inner: listener })
+    }
+}
+
+impl Drop for UnixDomainSocket {
+    fn drop(&mut self) {
+        let addr = self
+            .inner
+            .local_addr()
+            .expect("failed to get local address from listener");
+        let path = addr
+            .as_pathname()
+            .expect("failed to get path name from local address");
+        debug!("Removing socket file {path}", path = path.display());
+        fs::remove_file(path).ok();
+    }
+}
+
+impl Accept for UnixDomainSocket {
+    type Conn = tokio::net::UnixStream;
+    type Error = std::io::Error;
+
+    fn poll_accept(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        match self.inner.poll_accept(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok((socket, _addr))) => Poll::Ready(Some(Ok(socket))),
+            Poll::Ready(Err(err)) => Poll::Ready(Some(Err(err))),
+        }
+    }
+}


### PR DESCRIPTION
This binds the service on a Unix Domain Socket at `/tmp/cohosting.sock`. This feature is enabled on Unix-like systems only.